### PR TITLE
Pre workshop polish

### DIFF
--- a/lua/autorun/sh_mateditor.lua
+++ b/lua/autorun/sh_mateditor.lua
@@ -35,6 +35,7 @@ function advMat_Table:ValidateAdvmatData( data )
 		NoiseScaleY = data.NoiseScaleY or 1,
 		NoiseOffsetX = data.NoiseOffsetX or 0,
 		NoiseOffsetY = data.NoiseOffsetY or 0,
+		AlphaType = data.AlphaType or 0,
 	}
 	return dataValid
 
@@ -44,7 +45,7 @@ function advMat_Table:GetMaterialPathId( data )
 	local dataValid = self:ValidateAdvmatData( data )
 
 	local texture = string.Trim( dataValid.texture )
-	local uid = texture .. "+" .. dataValid.ScaleX .. "+" .. dataValid.ScaleY .. "+" .. dataValid.OffsetX .. "+" .. data.OffsetY .. "+" .. dataValid.ROffset
+	local uid = texture .. "+" .. dataValid.ScaleX .. "+" .. dataValid.ScaleY .. "+" .. dataValid.OffsetX .. "+" .. data.OffsetY .. "+" .. dataValid.ROffset .. "+" .. dataValid.AlphaType
 
 	if dataValid.UseNoise then
 		uid = uid .. dataValid.NoiseTexture .. "+" .. dataValid.NoiseScaleX .. "+" .. dataValid.NoiseScaleY .. "+" .. dataValid.NoiseOffsetX .. "+" .. dataValid.NoiseOffsetY
@@ -99,12 +100,20 @@ function advMat_Table:Set( ent, texture, data )
 			local matTable = {
 				["$basetexture"] = tempMat:GetName(),
 				["$basetexturetransform"] = "center .5 .5 scale " .. ( 1 / dataV.ScaleX ) .. " " .. ( 1 / dataV.ScaleY ) .. " rotate " .. dataV.ROffset .. " translate " .. dataV.OffsetX .. " " .. dataV.OffsetY,
-				["$vertexalpha"] = 0,
 				["$vertexcolor"] = 1
 			}
 
 			local iTexture = tempMat:GetTexture( "$basetexture" )
 			if not iTexture then return end
+
+			local alphaTypes = {
+				[1] = "$alphatest",
+				[3] = "$translucent"
+			}
+
+			if dataV.AlphaType > 0 then
+				matTable[ alphaTypes[data.AlphaType ] ] = 1
+			end
 
 			for index, currData in pairs( dataV ) do
 				if ( index:sub( 1, 1 ) == "$" ) then

--- a/lua/autorun/sh_mateditor.lua
+++ b/lua/autorun/sh_mateditor.lua
@@ -112,7 +112,6 @@ function advMat_Table:Set( ent, texture, data )
 			local iTexture = tempMat:GetTexture( "$basetexture" )
 			if not iTexture then return end
 
-
 			if dataV.AlphaType > 0 then
 				matTable[alphaTypes[data.AlphaType]] = 1
 			end

--- a/lua/autorun/sh_mateditor.lua
+++ b/lua/autorun/sh_mateditor.lua
@@ -63,7 +63,7 @@ end
 -- indexes are 1 / 3 to catch advmat 2'ed props, removed index 2 support, it was too specialized.
 local alphaTypes = {
 	[1] = "$alphatest",
-	[3] = "$vertexalpha",
+	[2] = "$vertexalpha",
 	[3] = "$translucent"
 }
 

--- a/lua/autorun/sh_mateditor.lua
+++ b/lua/autorun/sh_mateditor.lua
@@ -16,9 +16,11 @@ function advMat_Table:ResetAdvMaterial( ent )
 
 	if SERVER then
 		duplicator.ClearEntityModifier( ent, "material" )
+		duplicator.ClearEntityModifier( ent, "MaterialData" )
 	end
 
 	ent:SetMaterial( "" )
+	ent:SetNW2String( "AdvMaterialCRC", "" )
 end
 
 function advMat_Table:ValidateAdvmatData( data )

--- a/lua/autorun/sh_mateditor.lua
+++ b/lua/autorun/sh_mateditor.lua
@@ -63,6 +63,7 @@ end
 -- indexes are 1 / 3 to catch advmat 2'ed props, removed index 2 support, it was too specialized.
 local alphaTypes = {
 	[1] = "$alphatest",
+	[3] = "$vertexalpha",
 	[3] = "$translucent"
 }
 

--- a/lua/autorun/sh_mateditor.lua
+++ b/lua/autorun/sh_mateditor.lua
@@ -28,7 +28,7 @@ function advMat_Table:ValidateAdvmatData( data )
 		ScaleY = data.ScaleY or 1,
 		OffsetX = data.OffsetX or 0,
 		OffsetY = data.OffsetY or 0,
-		ROffset = data.ROffset or 0,
+		ROffset = data.ROffset or data.Rotate or 0, -- data.Rotate, catch advmat 2 rotation
 		UseNoise = data.UseNoise or false,
 		NoiseTexture = data.NoiseTexture or "detail/noise_detail_01",
 		NoiseScaleX = data.NoiseScaleX or 1,

--- a/lua/weapons/gmod_tool/stools/advmat.lua
+++ b/lua/weapons/gmod_tool/stools/advmat.lua
@@ -214,7 +214,10 @@ function TOOL:Think()
 		matrix:Rotate( Angle( 0, roffset, 0 ) )
 
 		if mat:GetString( "$basetexture" ) ~= texture then
-			mat:SetTexture( "$basetexture", Material( texture ):GetTexture( "$basetexture" ) )
+			local iMaterial = Material( texture ):GetTexture( "$basetexture" )
+			if iMaterial then
+				mat:SetTexture( "$basetexture", iMaterial )
+			end
 		end
 
 		mat:SetMatrix( "$basetexturetransform", matrix )

--- a/lua/weapons/gmod_tool/stools/advmat.lua
+++ b/lua/weapons/gmod_tool/stools/advmat.lua
@@ -178,7 +178,7 @@ function TOOL:Reload( trace )
 	if not IsValid( trace.Entity ) then return false end
 	if CLIENT then return true end
 
-	advMat_Table:Set( trace.Entity, "", {} )
+	advMat_Table:ResetAdvMaterial( trace.Entity )
 
 	return true
 end

--- a/lua/weapons/gmod_tool/stools/advmat.lua
+++ b/lua/weapons/gmod_tool/stools/advmat.lua
@@ -14,6 +14,8 @@ TOOL.ClientConVar["noisescalex"] = "1"
 TOOL.ClientConVar["noisescaley"] = "1"
 TOOL.ClientConVar["noiseoffsetx"] = "0"
 TOOL.ClientConVar["noiseoffsety"] = "0"
+TOOL.ClientConVar["alphatype"] = "0"
+
 TOOL.DetailWhitelist = {
 	"concrete",
 	"plaster",
@@ -55,6 +57,7 @@ function TOOL:LeftClick( trace )
 	local noisescaley = tonumber( self:GetClientInfo( "noisescaley" ) )
 	local noiseoffsetx = tonumber( self:GetClientInfo( "noiseoffsetx" ) )
 	local noiseoffsety = tonumber( self:GetClientInfo( "noiseoffsety" ) )
+	local alphatype = tonumber( self:GetClientInfo( "alphatype" ) )
 
 	advMat_Table:Set( trace.Entity, string.Trim( texture ):lower(), {
 		ScaleX = scalex,
@@ -67,7 +70,8 @@ function TOOL:LeftClick( trace )
 		NoiseScaleX = noisescalex,
 		NoiseScaleY = noisescaley,
 		NoiseOffsetX = noiseoffsetx,
-		NoiseOffsetY = noiseoffsety
+		NoiseOffsetY = noiseoffsety,
+		AlphaType = alphatype,
 	} )
 
 	return true
@@ -147,41 +151,41 @@ function TOOL:Think()
 			return
 		end
 
-		if not self.PreviewMat or not self.PreviewMatNoise then
+		if not self.PreviewMat or not self.PreviewNoisedMats then
 			self.PreviewMat = CreateMaterial( "AdvMatPreview", "VertexLitGeneric", {
 				["$basetexture"] = texture,
 				["$basetexturetransform"] = "center .5 .5 scale " .. ( 1 / scalex ) .. " " .. ( 1 / scaley ) .. " rotate " .. roffset .. " translate " .. offsetx .. " " .. offsety,
+				["$vertexalpha"] = 0,
 				["$vertexcolor"] = 1,
-				["$vertexalpha"] = 0
 			} )
 
-			local PreviewMatNoise = {}
+			local previewNoisedMats = {}
 
 			local previewMatTable = {
 				["$basetexture"] = texture,
 				["$basetexturetransform"] = "center .5 .5 scale " .. ( 1 / noisescalex ) .. " " .. ( 1 / noisescaley ) .. " rotate " .. roffset .. " translate " .. noiseoffsetx .. " " .. noiseoffsety,
-				["$vertexcolor"] = 1,
 				["$vertexalpha"] = 0,
+				["$vertexcolor"] = 1,
 				["$detailtexturetransform"] = "center .5 .5 scale 1 1 rotate 0 translate 0 0",
 				["$detailblendmode"] = 0,
 			}
 
 			previewMatTable["$detail"] = self.DetailTranslation[ "concrete" ]
-			PreviewMatNoise.concrete = CreateMaterial( "AdvMatPreviewNoiseConcrete", "VertexLitGeneric", previewMatTable )
+			previewNoisedMats.concrete = CreateMaterial( "AdvMatPreviewNoiseConcrete", "VertexLitGeneric", previewMatTable )
 
 			previewMatTable["$detail"] = self.DetailTranslation[ "plaster" ]
-			PreviewMatNoise.plaster = CreateMaterial( "AdvMatPreviewNoisePlaster", "VertexLitGeneric", previewMatTable )
+			previewNoisedMats.plaster = CreateMaterial( "AdvMatPreviewNoisePlaster", "VertexLitGeneric", previewMatTable )
 
 			previewMatTable["$detail"] = self.DetailTranslation[ "metal" ]
-			PreviewMatNoise.metal = CreateMaterial( "AdvMatPreviewNoiseMetal", "VertexLitGeneric", previewMatTable )
+			previewNoisedMats.metal = CreateMaterial( "AdvMatPreviewNoiseMetal", "VertexLitGeneric", previewMatTable )
 
 			previewMatTable["$detail"] = self.DetailTranslation[ "wood" ]
-			PreviewMatNoise.wood = CreateMaterial( "AdvMatPreviewNoiseWood", "VertexLitGeneric", previewMatTable )
+			previewNoisedMats.wood = CreateMaterial( "AdvMatPreviewNoiseWood", "VertexLitGeneric", previewMatTable )
 
 			previewMatTable["$detail"] = self.DetailTranslation[ "rock" ]
-			PreviewMatNoise.rock = CreateMaterial( "AdvMatPreviewNoiseRock", "VertexLitGeneric", previewMatTable )
+			previewNoisedMats.rock = CreateMaterial( "AdvMatPreviewNoiseRock", "VertexLitGeneric", previewMatTable )
 
-			self.PreviewMatNoise = PreviewMatNoise
+			self.PreviewNoisedMats = previewNoisedMats
 
 		end
 
@@ -197,12 +201,12 @@ function TOOL:Think()
 				noiseTexture = "concrete"
 			end
 
-			self.PreviewMatNoise[noiseTexture]:SetMatrix( "$detailtexturetransform", noiseMatrix )
+			self.PreviewNoisedMats[noiseTexture]:SetMatrix( "$detailtexturetransform", noiseMatrix )
 
 			if self.noise ~= self:GetClientInfo( "noisetexture" ) then
 				self.noise = noiseTexture
 
-				self.Preview = self.PreviewMatNoise[noiseTexture]
+				self.Preview = self.PreviewNoisedMats[noiseTexture]
 			end
 		end
 
@@ -300,7 +304,7 @@ do
 		end
 
 		CPanel:CheckBox( "#tool.advmat.usenoise", "advmat_usenoise" )
-		CPanel:ControlHelp( "If this box is checked, your material will be sharpened using an HD detail texture, controlled by the settings below." )
+		CPanel:ControlHelp( "#tool.advmat.usenoise.helptext" )
 
 		CPanel:AddControl( "ComboBox", {
 			Label = "#tool.advmat.noisetexture",
@@ -319,6 +323,13 @@ do
 				LocalPlayer():ConCommand( "advmat_noise" .. k:lower() .. " " .. v )
 			end
 		end
+
+		local alphabox = CPanel:ComboBox( "#tool.advmat.alphatype", "advmat_alphatype" )
+		alphabox:AddChoice( "#tool.advmat.alphatype.none", 0 )
+		alphabox:AddChoice( "#tool.advmat.alphatype.alphatest", 1 )
+		alphabox:AddChoice( "#tool.advmat.alphatype.translucent", 3 )
+		CPanel:ControlHelp( "#tool.advmat.alphatype.helptext" )
+
 	end
 end
 /*
@@ -337,7 +348,9 @@ if CLIENT then
 	language.Add( "tool.advmat.offsetx", "Horizontal Translation" )
 	language.Add( "tool.advmat.offsety", "Vertical Translation" )
 	language.Add( "tool.advmat.roffset", "Rotation" )
+
 	language.Add( "tool.advmat.usenoise", "Use noise texture" )
+	language.Add( "tool.advmat.usenoise.helptext", "If this box is checked, your material will be sharpened using an HD detail texture, controlled by the settings below." )
 
 	language.Add( "tool.advmat.noisetexture", "Detail type" )
 
@@ -349,6 +362,12 @@ if CLIENT then
 	language.Add( "tool.advmat.details.metal", "Metal" )
 	language.Add( "tool.advmat.details.wood", "Wood" )
 	language.Add( "tool.advmat.details.rock", "Rock" )
+
+	language.Add( "tool.advmat.alphatype", "Alpha Type" )
+	language.Add( "tool.advmat.alphatype.none", "None" )
+	language.Add( "tool.advmat.alphatype.alphatest", "Alphatest" )
+	language.Add( "tool.advmat.alphatype.translucent", "Translucent" )
+	language.Add( "tool.advmat.alphatype.helptext", "Texture-level transparency, for windows, foliage, etc. If unsure, set to None, or AlphaTest." )
 
 	list.Set( "tool.advmat.details", "#tool.advmat.details.concrete", { advmat_noisetexture = "concrete" } )
 	list.Set( "tool.advmat.details", "#tool.advmat.details.plaster", { advmat_noisetexture = "plaster" } )

--- a/lua/weapons/gmod_tool/stools/advmat.lua
+++ b/lua/weapons/gmod_tool/stools/advmat.lua
@@ -42,7 +42,6 @@ TOOL.Information = {
 
 local canAdvmatPlayers = CreateConVar( "advmat_canmaterializeplayers", "1", { FCVAR_ARCHIVE, FCVAR_REPLICATED }, "Can admins change the Advanced Material of players?", 0, 1 )
 
--- admins can advmat players
 function TOOL:LegalMaterialize( trace )
 	if trace.Entity:IsPlayer() then
 		if self:GetOwner():IsAdmin() and canAdvmatPlayers:GetBool() then return true end

--- a/lua/weapons/gmod_tool/stools/advmat.lua
+++ b/lua/weapons/gmod_tool/stools/advmat.lua
@@ -291,7 +291,7 @@ if CLIENT then
 	function TOOL:DrawHUD()
 	end
 
-	hook.Add( "PostDrawOpaqueRenderables", "AdvMatPreview", function()
+	hook.Add( "PostDrawTranslucentRenderables", "AdvMatPreview", function()
 		local player = LocalPlayer()
 
 		if not IsValid( player ) then return end
@@ -309,6 +309,11 @@ if CLIENT then
 
 		if not IsValid( ent ) then return end
 		local mat = toolObj:GetPreviewMat()
+
+		-- according to DrawModel on wiki this will fix a crash
+		local entsFlags = ent:GetEFlags()
+		if bit.band( entsFlags, EF_BONEMERGE ) ~= 0 then return end
+		if bit.band( entsFlags, EF_NODRAW ) ~= 0 then return end
 
 		render.MaterialOverride( mat )
 			ent:DrawModel()

--- a/lua/weapons/gmod_tool/stools/advmat.lua
+++ b/lua/weapons/gmod_tool/stools/advmat.lua
@@ -396,6 +396,7 @@ do
 		local alphabox = CPanel:ComboBox( "#tool.advmat.alphatype", "advmat_alphatype" )
 		alphabox:AddChoice( "#tool.advmat.alphatype.none", 0 )
 		alphabox:AddChoice( "#tool.advmat.alphatype.alphatest", 1 )
+		alphabox:AddChoice( "#tool.advmat.alphatype.vertexalpha", 2 )
 		alphabox:AddChoice( "#tool.advmat.alphatype.translucent", 3 )
 		CPanel:ControlHelp( "#tool.advmat.alphatype.helptext" )
 
@@ -436,6 +437,7 @@ if CLIENT then
 	language.Add( "tool.advmat.alphatype.none", "None" )
 	language.Add( "tool.advmat.alphatype.alphatest", "Alphatest" )
 	language.Add( "tool.advmat.alphatype.translucent", "Translucent" )
+	language.Add( "tool.advmat.alphatype.vertexalpha", "Vertexalpha" )
 	language.Add( "tool.advmat.alphatype.helptext", "Texture-level transparency, for windows, foliage, etc. If unsure, set to None, or AlphaTest." )
 
 	list.Set( "tool.advmat.details", "#tool.advmat.details.concrete", { advmat_noisetexture = "concrete" } )

--- a/lua/weapons/gmod_tool/stools/advmat.lua
+++ b/lua/weapons/gmod_tool/stools/advmat.lua
@@ -40,15 +40,18 @@ TOOL.Information = {
 	MATERIALIZE
 */
 
+local canAdvmatPlayers = CreateConVar( "advmat_canmaterializeplayers", "1", { FCVAR_ARCHIVE, FCVAR_REPLICATED }, "Can admins change the Advanced Material of players?", 0, 1 )
+
 -- admins can advmat players
 function TOOL:LegalMaterialize( trace )
 	if trace.Entity:IsPlayer() then
-		if self:GetOwner():IsAdmin() then return true end
+		if self:GetOwner():IsAdmin() and canAdvmatPlayers:GetBool() then return true end
 		return nil
 	end
 
 	return true
 end
+
 
 function TOOL:LeftClick( trace )
 	if not IsValid( trace.Entity ) then return false end
@@ -305,7 +308,11 @@ if CLIENT then
 		if not toolObj then return end
 		if toolObj.Name ~= "Advanced Material" then return end
 
-		local ent = player:GetEyeTrace().Entity
+		local eyeTr = player:GetEyeTrace()
+
+		if not toolObj:LegalMaterialize( eyeTr ) then return end
+
+		local ent = eyeTr.Entity
 
 		if not IsValid( ent ) then return end
 		local mat = toolObj:GetPreviewMat()

--- a/lua/weapons/gmod_tool/stools/advmat.lua
+++ b/lua/weapons/gmod_tool/stools/advmat.lua
@@ -42,6 +42,7 @@ TOOL.Information = {
 
 local canAdvmatPlayers = CreateConVar( "advmat_canmaterializeplayers", "1", { FCVAR_ARCHIVE, FCVAR_REPLICATED }, "Can admins change the Advanced Material of players?", 0, 1 )
 
+-- admins can advmat players
 function TOOL:LegalMaterialize( trace )
 	if trace.Entity:IsPlayer() then
 		if self:GetOwner():IsAdmin() and canAdvmatPlayers:GetBool() then return true end

--- a/lua/weapons/gmod_tool/stools/advmat.lua
+++ b/lua/weapons/gmod_tool/stools/advmat.lua
@@ -318,9 +318,8 @@ if CLIENT then
 		local mat = toolObj:GetPreviewMat()
 
 		-- according to DrawModel on wiki this will fix a crash
-		local entsFlags = ent:GetEFlags()
-		if bit.band( entsFlags, EF_BONEMERGE ) ~= 0 then return end
-		if bit.band( entsFlags, EF_NODRAW ) ~= 0 then return end
+		if ent:IsEffectActive( EF_BONEMERGE ) then return end
+		if ent:IsEffectActive( EF_NODRAW ) then return end
 
 		render.MaterialOverride( mat )
 			ent:DrawModel()

--- a/lua/weapons/gmod_tool/stools/advmat.lua
+++ b/lua/weapons/gmod_tool/stools/advmat.lua
@@ -40,9 +40,19 @@ TOOL.Information = {
 	MATERIALIZE
 */
 
+-- admins can advmat players
+function TOOL:LegalMaterialize( trace )
+	if trace.Entity:IsPlayer() then
+		if self:GetOwner():IsAdmin() then return true end
+		return nil
+	end
+
+	return true
+end
+
 function TOOL:LeftClick( trace )
 	if not IsValid( trace.Entity ) then return false end
-	if trace.Entity:IsPlayer() then return false end
+	if not self:LegalMaterialize( trace ) then return false end
 	if CLIENT then return true end
 
 	local texture = self:GetClientInfo( "texture" )
@@ -77,22 +87,52 @@ function TOOL:LeftClick( trace )
 	return true
 end
 
+local function isValidMaterial( matStr )
+	if not matStr then return end
+	if matStr[1] == "*" then return end -- **DISPLACEMENT**, **STUDIO**, etc
+	if matStr == "" then return end
+
+	return true
+end
+
+function TOOL:GetEntsMaterial( ent )
+	local entsOverrideMat = ent:GetMaterial()
+	if isValidMaterial( entsOverrideMat ) then return entsOverrideMat end
+
+	local entsBaseMats = ent:GetMaterials()
+	local primaryMat = entsBaseMats[1]
+
+	if isValidMaterial( primaryMat ) then return primaryMat end
+end
+
 -- copy mats
 function TOOL:RightClick( trace )
-	if trace.Entity:IsPlayer() then return false end
+	if not self:LegalMaterialize( trace ) then return false end
 	if CLIENT then return true end
 
-	local bIsMat = false
-
-	if IsValid( trace.Entity ) and trace.Entity:GetMaterial() ~= "" and trace.Entity:GetMaterial():sub( 1, 1 ) ~= "!" then
-		bIsMat = true
+	local matData = nil
+	local validAdvMat = nil
+	if IsValid( trace.Entity ) then
+		matData = trace.Entity.MaterialData
+		validAdvMat = matData and isValidMaterial( matData.texture )
 	end
 
-	if not bIsMat and trace.HitTexture[1] == "*" and not trace.Entity.MaterialData then
-		return false
+	local matString = ""
+
+	-- building a new material
+	if not validAdvMat then
+		if IsValid( trace.Entity ) then
+			matString = self:GetEntsMaterial( trace.Entity )
+		elseif isValidMaterial( trace.HitTexture ) then
+			matString = trace.HitTexture
+		end
+	else
+		matString = matData.texture
 	end
 
-	local tempMat = Material( trace.HitTexture )
+	if not isValidMaterial( matString ) then return false end -- displacement or smth
+
+	local tempMat = Material( matString )
 	local hitNoise = tempMat:GetString( "$detail" )
 	local noiseTexture = false
 
@@ -103,16 +143,24 @@ function TOOL:RightClick( trace )
 		end
 	end
 
-	local data = trace.Entity.MaterialData or {
-		texture = bIsMat and trace.Entity:GetMaterial() or trace.HitTexture,
-		scalex = 1,
-		scaley = 1,
-		offsetx = 0,
-		offsety = 0,
-		roffset = 0,
-		usenoise = noiseTexture and 1 or 0,
-		noisetexture = noiseTexture
-	}
+	local data = nil
+
+	if matData then
+		data = matData
+	elseif isValidMaterial( matString ) then
+		data = {
+			texture = matString,
+			scalex = 1,
+			scaley = 1,
+			offsetx = 0,
+			offsety = 0,
+			roffset = 0,
+			usenoise = noiseTexture and 1 or 0,
+			noisetexture = noiseTexture
+		}
+	else
+		return false
+	end
 
 	for index, var in pairs( data ) do
 		if isbool( var ) then continue end
@@ -130,6 +178,16 @@ function TOOL:Reload( trace )
 	advMat_Table:Set( trace.Entity, "", {} )
 
 	return true
+end
+
+function TOOL:GetPreviewMat( usingNoise )
+	usingNoise = usingNoise or tobool( self:GetClientInfo( "usenoise" ) )
+
+	if usingNoise then
+		return self.PreviewNoise
+	else
+		return self.PreviewMat
+	end
 end
 
 function TOOL:Think()
@@ -197,6 +255,7 @@ function TOOL:Think()
 
 			local noiseTexture = self:GetClientInfo( "noisetexture" )
 
+			-- invalid noise texture
 			if not table.HasValue( self.DetailWhitelist, noiseTexture:lower() ) then
 				noiseTexture = "concrete"
 			end
@@ -206,11 +265,11 @@ function TOOL:Think()
 			if self.noise ~= self:GetClientInfo( "noisetexture" ) then
 				self.noise = noiseTexture
 
-				self.Preview = self.PreviewNoisedMats[noiseTexture]
+				self.PreviewNoise = self.PreviewNoisedMats[noiseTexture]
 			end
 		end
 
-		local mat = bUseNoise and self.Preview or self.PreviewMat
+		local mat = self:GetPreviewMat( bUseNoise )
 
 		local matrix = Matrix()
 		matrix:Scale( Vector( 1 / scalex, 1 / scaley, 1 ) )
@@ -230,7 +289,6 @@ end
 
 if CLIENT then
 	function TOOL:DrawHUD()
-
 	end
 
 	hook.Add( "PostDrawOpaqueRenderables", "AdvMatPreview", function()
@@ -250,12 +308,11 @@ if CLIENT then
 		local ent = player:GetEyeTrace().Entity
 
 		if not IsValid( ent ) then return end
-		local mat = tobool( toolObj:GetClientInfo( "usenoise" ) ) and toolObj.Preview or toolObj.PreviewMat
+		local mat = toolObj:GetPreviewMat()
 
 		render.MaterialOverride( mat )
 			ent:DrawModel()
 		render.MaterialOverride()
-
 	end )
 end
 


### PR DESCRIPTION
General polish of copying materials.
Can now copy ent's "innate" materials.
+Allow admins to change advanced material of players.

Fixed the preview not drawing sometimes.
Fixed a potential crash issue with the preview, according to the wiki at least.