### PR TITLE
Stop using net.WriteTable, improve net efficiency

### DIFF
--- a/lua/mateditor/sh_mateditor.lua
+++ b/lua/mateditor/sh_mateditor.lua
@@ -202,10 +202,10 @@ local requestQueueBatchSize = 50
 
 if CLIENT then
 	local function readDecimal()
-		return net.ReadUInt( 10 ) / 100
+		return net.ReadUInt( 16 ) / 100
 	end
 
-	net.Receive( "AdvMatMaterialize", function( len )
+	net.Receive( "AdvMatMaterialize", function()
 		local ent = net.ReadEntity()
 		if not IsValid( ent ) then return end
 
@@ -267,7 +267,7 @@ if CLIENT then
 else
 	local function writeDecimal( num )
 		local mult = math.floor( num * 100 )
-		net.WriteUInt( mult, 10 )
+		net.WriteUInt( mult, 16 )
 	end
 
 	function advMat_Table:Sync( ent, ply )

--- a/lua/mateditor/sh_mateditor.lua
+++ b/lua/mateditor/sh_mateditor.lua
@@ -199,10 +199,12 @@ function advMat_Table:Set( ent, texture, data )
 end
 
 local requestQueueBatchSize = 50
+local bitSize = 17
+local divisor = 100
 
 if CLIENT then
 	local function readDecimal()
-		return net.ReadUInt( 16 ) / 100
+		return net.ReadInt( bitSize ) / divisor
 	end
 
 	net.Receive( "AdvMatMaterialize", function()
@@ -266,8 +268,8 @@ if CLIENT then
 	end )
 else
 	local function writeDecimal( num )
-		local mult = math.floor( num * 100 )
-		net.WriteUInt( mult, 16 )
+		local mult = math.floor( num * divisor )
+		net.WriteInt( mult, bitSize )
 	end
 
 	function advMat_Table:Sync( ent, ply )

--- a/lua/mateditor/sh_mateditor.lua
+++ b/lua/mateditor/sh_mateditor.lua
@@ -268,7 +268,7 @@ if CLIENT then
 	end )
 else
 	local function writeDecimal( num )
-		local mult = math.floor( num * divisor )
+		local mult = math.floor( math.Round( num * divisor ) )
 		net.WriteInt( mult, bitSize )
 	end
 


### PR DESCRIPTION
Writes everything directly instead of using net.WriteTable, also instead of using WriteFloat we're writing UInts as it's more effecient and our numbers dont ever go above 2 decimals. Saves ~5x the bandwidth without any loss.

The table remains the same:
![image](https://github.com/user-attachments/assets/f49506c5-6f31-4b57-a292-89a2166c94af)
